### PR TITLE
Fixed Role serialisation error.

### DIFF
--- a/src/main/java/com/benoly/auth/model/Identified.java
+++ b/src/main/java/com/benoly/auth/model/Identified.java
@@ -3,8 +3,10 @@ package com.benoly.auth.model;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 
+import java.io.Serializable;
+
 @Data
-abstract class Identified {
+abstract class Identified implements Serializable {
     @Id
     private String id;
 }

--- a/src/main/java/com/benoly/auth/model/Role.java
+++ b/src/main/java/com/benoly/auth/model/Role.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -13,7 +14,8 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class Role extends Identified {
+public class Role extends Identified implements Serializable {
+    private static final long serialVersionUID = 1373828140005067324L;
     private String name;
     private String description;
     private Set<Authority> authorities = new HashSet<>();

--- a/src/main/java/com/benoly/auth/model/User.java
+++ b/src/main/java/com/benoly/auth/model/User.java
@@ -16,6 +16,7 @@ import java.util.*;
 @Document
 @NoArgsConstructor
 public class User implements UserDetails {
+    private static final long serialVersionUID = 8668310170868956407L;
     @Id
     private String id;
     private String username;


### PR DESCRIPTION
The role entity was not serializable. this caused the CustomAuthorizationCodeService to throw an error while trying to serialize the User object in the Authentication principal.

This was a simple fix